### PR TITLE
store_share: modify compare_share to avoid fail

### DIFF
--- a/src/pool.c
+++ b/src/pool.c
@@ -337,11 +337,7 @@ compare_share(const MDB_val *a, const MDB_val *b)
 {
     const share_t *va = (const share_t*) a->mv_data;
     const share_t *vb = (const share_t*) b->mv_data;
-    int sc = strcmp(va->address, vb->address);
-    if (sc == 0)
-        return (va->timestamp < vb->timestamp) ? -1 : 1;
-    else
-        return sc;
+    return (va->timestamp < vb->timestamp) ? -1 : 1;
 }
 
 static int


### PR DESCRIPTION
compare_share() doesn't implement strict ordering
store_share() uses MDB_APPENDDUP to avoid problem with compare_share
MDB_APPENDDUP may fail since the following pair of valid shares can't added in specified order:
  1. {share1, share2 | (share1.timestamp < share2.timestamp) && (share1.address > share2.address)}
  2. {share1, share2 | (share1.timestamp > share2.timestamp) && (share1.address == share2.address)}

If there is no plan to avoid usage of MDB_APPENDDUP in store_share()
then compare_share() can be modified to use only timestamp field
thus avoid MDB_APPENDDUP fail in the first case.