### PR TITLE
stats: worker count and list

### DIFF
--- a/src/pool.h
+++ b/src/pool.h
@@ -33,6 +33,8 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #define POOL_H
 
 void account_hr(double *avg, const char *address);
+uint64_t account_wc(const char *address);
+void account_rl(char *rig_list_out, char *end_pt, const char *address);
 uint64_t account_balance(const char *address);
 
 #endif


### PR DESCRIPTION
Add support for the xmrig --rig-id option, add worker_count as a statistic in /stats, and a list of up to as many connected rigs that will fit in a 1mb buffer

I know this is probably terrible, please be gentle, my c skills are rusty.