### PR TITLE
test: add testkit

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,4 @@
 build
-
+tools/local/testenv
+tools/local/.env*
+*.pyc

--- a/test/integ/test_env.py
+++ b/test/integ/test_env.py
@@ -1,0 +1,57 @@
+#!/usr/bin/env python
+
+import ipaddress
+from os.path import exists
+from testlib.util import load_env, get_env_file
+
+def test_env():
+    env_dict = load_env(get_env_file())
+    config_items = [
+        "monerod_ip",
+        "monerod_rpc_port",
+        "wallet_rpc_ip",
+        "wallet_rpc_port",
+        "wallet_file",
+        "wallet_password",
+        "nettype",
+        "test_pool_port",
+        "test_pool_webui_port",
+        "test_pool_wallet_address",
+        "test_pool_fee_wallet_address",
+        "test_build_dir"
+    ]
+    for key in config_items:
+        assert key in env_dict.keys()
+    assert isinstance(env_dict['nettype'], str)
+    assert env_dict['nettype'] in ['mainnet', 'stagenet', 'testnet']
+    int_list = [
+        'wallet_rpc_port',
+        'monerod_rpc_port',
+        'test_pool_port',
+        'test_pool_webui_port'
+    ]
+    ip_list = [
+        'monerod_ip',
+        'wallet_rpc_ip',
+    ]
+    str_list = [
+        'test_pool_wallet_address',
+        'test_pool_fee_wallet_address'
+    ]
+    for key in int_list:
+        assert isinstance(int(env_dict[key]), int)
+    for key in ip_list:
+        try:
+            ipaddress.ip_address(env_dict[key])
+        except ipaddress.AddressValueError as e:
+            assert True
+    for key in str_list:
+        assert isinstance(env_dict[key], str)
+    path_split = env_dict['test_build_dir'].split("/")
+    second = ''
+    test_path = ''
+    for i in range(0,len(path_split)-1):
+        test_path = test_path + second + path_split[i]
+        second = '/'
+    assert exists(test_path)
+    

--- a/test/integ/test_monero.py
+++ b/test/integ/test_monero.py
@@ -1,0 +1,14 @@
+#!/usr/bin/env python
+
+from monero.wallet import Wallet
+from monero.backends.jsonrpc import JSONRPCWallet
+from monero.numbers import Decimal
+from testlib.util import load_env, get_env_file
+
+def test_pool_wallet_rpc():
+    ENV=load_env(get_env_file())
+    host=ENV['wallet_rpc_ip']
+    port=ENV['wallet_rpc_port']
+    w = Wallet(JSONRPCWallet(host=host, port=port))
+    assert w.address() == ENV['test_pool_wallet_address']
+    assert isinstance(w.balance(), Decimal)

--- a/test/integ/test_pool.py
+++ b/test/integ/test_pool.py
@@ -1,0 +1,132 @@
+#!/usr/bin/env python
+
+import socket
+import json
+import requests
+from uuid import uuid4
+from time import sleep
+from pytest import skip
+from os.path import exists
+from testlib.util import load_env, get_env_file
+from subprocess import Popen, PIPE
+
+def test_miner_connect():
+    ENV=load_env(get_env_file())
+    port = ENV['test_pool_port']
+    host = "127.0.0.1"
+    pool_socket = socket.socket()
+    pool_socket.connect((host, int(port)))
+    json_object = {
+        "id":1,
+        "jsonrpc":"2.0",
+        "method":"login",
+        "params":{
+            "login":ENV['test_pool_fee_wallet_address'],
+            "pass":"d=300000",
+            "agent": "monero-pool integration test",
+            "rigid":"monero-pool_int_test",
+            "algo":["rx/0"]
+            }
+        }
+    json_string = json.dumps(json_object)
+    json_string = json_string + "\n"
+    raw_data = bytes(json_string, 'utf-8')
+    pool_socket.sendall(raw_data)
+    response_data = pool_socket.recv(4096)
+    pool_socket.shutdown(socket.SHUT_RDWR)
+    pool_socket.close()
+    json_object = json.loads(str(response_data, 'utf-8'))
+    key_check = ['id', 'jsonrpc', 'error', 'result']
+    for key in key_check:
+        assert key in json_object.keys()
+    assert isinstance(json_object['result'], dict)
+    assert isinstance(json_object['id'], int)
+    assert json_object['jsonrpc'] == "2.0"
+    assert json_object['error'] == None
+    key_check = ['id', 'job', 'status']
+    for key in key_check:
+        assert key in json_object['result'].keys()
+    assert isinstance(json_object['result']['job'], dict)
+    key_check = ['blob', 'job_id', 'target', 'height', 'seed_hash', 'next_seed_hash']
+    for key in key_check:
+        assert key in json_object['result']['job'].keys()
+    assert json_object['result']['status'] == "OK"
+
+def test_actual_mining():
+    ENV=load_env(get_env_file())
+    port = ENV['test_pool_port']
+    wallet = ENV['test_pool_fee_wallet_address']
+    webui_port = ENV['test_pool_webui_port']
+    proc = Popen("which xmrig", stdout=PIPE, shell=True)
+    (xmrig_output, err) = proc.communicate()
+    xmrig_cmd = str(xmrig_output, 'utf-8').strip()
+    assert err == None
+    assert len(xmrig_cmd) > 0
+    assert exists(xmrig_cmd)
+    xmrig_uuid = uuid4()
+    full_cmd = "{} --log-file={}/xmrig-{}.log --algo rx/0 -u {} -o localhost:{} -p d=1000 --rig-id monero_pool_int_test".format(xmrig_cmd, ENV['test_build_dir'], xmrig_uuid, wallet, port)
+    proc = Popen(full_cmd, stdout=PIPE, shell=True)
+    pid = proc.pid
+    pid_file_path = "{}/xmrig-{}.pid".format(ENV['test_build_dir'], xmrig_uuid)
+    pid_fh = open(pid_file_path, 'w')
+    pid_fh.write(str(pid))
+    pid_fh.close()
+    sleep(60)
+    uri = "http://localhost:{}/stats".format(webui_port)
+    cookies = {'wa': wallet}
+    r = requests.get(uri, cookies=cookies)
+    r.raise_for_status()
+    proc = Popen("/usr/bin/kill {}".format(pid), stdout=PIPE, shell=True)
+    assert r.status_code == 200
+    assert r.headers['content-type'] == "application/json"
+    json_object = r.json()
+    assert json_object['worker_count'] > 0
+    assert json_object['connected_miners'] > 0
+    assert json_object['miner_hashrate'] > 0
+
+def test_mine_block():
+    ENV=load_env(get_env_file())
+    if ENV['nettype'] == "mainnet":
+        skip("Do not try mining a block on mainnet")
+    port=ENV['test_pool_port']
+    wallet=ENV['test_pool_fee_wallet_address']
+    proc = Popen("which xmrig", stdout=PIPE, shell=True)
+    (xmrig_output, err) = proc.communicate()
+    xmrig_cmd = str(xmrig_output, 'utf-8').strip()
+    assert err == None
+    assert len(xmrig_cmd) > 0
+    assert exists(xmrig_cmd)
+    xmrig_uuid = uuid4()
+    full_cmd = "{} --log-file={}/xmrig-{}.log --algo rx/0 -u {} -o localhost:{} -p d=300000 --rig-id monero_pool_int_test".format(xmrig_cmd, ENV['test_build_dir'], xmrig_uuid, wallet, port)
+    proc = Popen(full_cmd, stdout=PIPE, shell=True)
+    pid = proc.pid
+    pid_file_path = "{}/xmrig-{}.pid".format(ENV['test_build_dir'], xmrig_uuid)
+    pid_fh = open(pid_file_path, 'w')
+    pid_fh.write(str(pid))
+    pid_fh.close()
+    webui_port = ENV['test_pool_webui_port']
+    uri = "http://localhost:{}/stats".format(webui_port)
+    r = requests.get(uri)
+    r.raise_for_status()
+    assert r.status_code == 200
+    assert r.headers['content-type'] == "application/json"
+    json_object = r.json()
+    pool_blocks_found = json_object['pool_blocks_found']
+    retry = 0
+    max_retry = 60
+    while True:
+        r = requests.get(uri)
+        r.raise_for_status()
+        assert r.status_code == 200
+        assert r.headers['content-type'] == "application/json"
+        json_object = r.json()
+        new_count = json_object['pool_blocks_found']
+        if new_count > pool_blocks_found:
+            break
+        retry = retry + 1
+        if retry > max_retry:
+            proc = Popen("/usr/bin/kill {}".format(pid), stdout=PIPE, shell=True)
+            assert False
+        sleep(60)
+    proc = Popen("/usr/bin/kill {}".format(pid), stdout=PIPE, shell=True)
+    assert new_count > pool_blocks_found

--- a/test/integ/test_webui.py
+++ b/test/integ/test_webui.py
@@ -1,0 +1,73 @@
+#!/usr/bin/env python
+
+import requests
+from testlib.util import load_env, get_env_file
+
+def test_webui_stats():
+    ENV = load_env(get_env_file())
+    port=ENV['test_pool_webui_port']
+    uri = "http://127.0.0.1:{}/stats".format(port)
+    r = requests.get(uri)
+    r.raise_for_status()
+    assert r.status_code == 200
+    assert r.headers['content-type'] == "application/json"
+    data = r.json()
+    int_list = [
+        'pool_hashrate',
+        'round_hashes',
+        'network_hashrate',
+        'network_height',
+        'last_template_fetched',
+        'last_block_found',
+        'pool_blocks_found',
+        'pool_port',
+        'pool_ssl_port',
+        'allow_self_select',
+        'connected_miners',
+        'miner_hashrate',
+        'worker_count'
+    ]
+    float_list = [
+        'pool_fee',
+        'miner_balance',
+        'payment_threshold'
+    ]
+    for key in int_list:
+        assert key in data.keys()
+        assert isinstance(data[key], int)
+    assert 'miner_hashrate_stats' in data.keys()
+    assert isinstance(data['miner_hashrate_stats'], list)
+    for key in float_list:
+        assert key in data.keys()
+        assert isinstance(data[key], float)
+    assert data['miner_hashrate_stats'] == [0,0,0,0,0,0]
+
+def test_webui_stats_with_wa():
+    ENV = load_env(get_env_file())
+    port=ENV['test_pool_webui_port']
+    cookies = {'wa': ENV['test_pool_fee_wallet_address']}
+    uri = "http://127.0.0.1:{}/stats".format(port)
+    r = requests.get(uri, cookies=cookies)
+    r.raise_for_status()
+    assert r.headers['content-type'] == "application/json"
+    assert r.status_code == 200
+
+def test_webui_pool_page():
+    ENV = load_env(get_env_file())
+    port=ENV['test_pool_webui_port']
+    uri = "http://127.0.0.1:{}/".format(port)
+    r = requests.get(uri)
+    r.raise_for_status
+    assert r.headers['content-type'] == "text/html"
+    assert r.status_code == 200
+
+def test_webui_workers():
+    ENV = load_env(get_env_file())
+    port=ENV['test_pool_webui_port']
+    uri = "http://127.0.0.1:{}/workers".format(port)
+    r = requests.get(uri)
+    r.raise_for_status
+    assert r.headers['content-type'] == "application/json"
+    assert r.status_code == 200
+    data = r.json()
+    assert isinstance(data, list)

--- a/test/integ/testlib/util.py
+++ b/test/integ/testlib/util.py
@@ -1,0 +1,27 @@
+#!/usr/bin/env python
+
+from os.path import exists
+from subprocess import Popen, PIPE
+
+def load_env(env_file):
+    content = ""
+    env_dict = {}
+    assert exists(env_file)
+    with open(env_file, 'r') as fh:
+        content = fh.read()
+    for line in content.splitlines():
+        k, v = line.split("=")
+        v = v.replace('"','')
+        env_dict[k] = v
+    return env_dict
+
+def get_env_file():
+    proc = Popen("git rev-parse --show-toplevel", stdout=PIPE, shell=True)
+    (git_root, err) = proc.communicate()
+    assert err == None
+    git_root = str(git_root, 'utf-8')
+    git_root = git_root.strip('\n')
+    assert exists(git_root)
+    env_file = "{}/tools/local/.env".format(git_root)
+    assert exists(env_file)
+    return env_file

--- a/tools/local/README.md
+++ b/tools/local/README.md
@@ -1,0 +1,41 @@
+`create_test_env.sh` - creates the runtime environment
+<img width="767" alt="create_test_env" src="https://user-images.githubusercontent.com/20960742/126140648-091783b7-3834-4a85-b4d9-40523c74df7f.png">
+
+`launch.sh` - builds and starts the pool services for testing, $1=branchname $2=buildtype  if not specified they will default to master/debug
+<img width="767" alt="launch" src="https://user-images.githubusercontent.com/20960742/126141250-643b9863-678b-4b90-807e-49724af22dd7.png">
+
+`run_integ_tests.sh` - run all integration tests or specify a single test file to run at $1
+<img width="769" alt="run_integ_tests sh" src="https://user-images.githubusercontent.com/20960742/126141271-a23340da-8a05-41e4-bc67-5be896343222.png">
+
+`launch_and_test.sh` - launches, and runs integration tests, and then kills the environment takes the same parameters as launch.sh
+
+`kill_all_test_env_processes.sh` - used to kill any stray processes 
+
+A private stagenet with fixed diff of 300000 can pass all tests in two minutes with a hashrate of 2500h/s
+
+If you want to setup your own stagenet see:
+example stagenet https://github.com/moneroexamples/private-testnet/blob/master/make_private_stagenet.sh
+
+If you start an empty blockchain stagenet or testnet you may want to edit the src/hardforks/hardforks.cpp before you compile your private [stage|test]net to quickly get to the latest version.   Mine in monerod after the [stage|test]net is setup, and then start mining with the pool software after hitting the latest version of the block.   See the below changes to stagenet_hard_forks. Only do this on a private [state|test]net.
+
+```
+const hardfork_t stagenet_hard_forks[] = {
+  // version 1 from the start of the blockchain
+  { 1, 1, 0, 1341378000 },
+
+  // versions 2-7 in rapid succession from March 13th, 2018
+  { 2, 2, 0, 1521000000 },
+  { 3, 3, 0, 1521120000 },
+  { 4, 4, 0, 1521240000 },
+  { 5, 5, 0, 1521360000 },
+  { 6, 6, 0, 1521480000 },
+  { 7, 7, 0, 1521600000 },
+  { 8, 8, 0, 1537821770 },
+  { 9, 9, 0, 1537821771 },
+  { 10, 10, 0, 1550153694 },
+  { 11, 11, 0, 1550225678 },
+  { 12, 12, 0, 1571419280 },
+  { 13, 675405, 0, 1598180817 },
+  { 14, 676125, 0, 1598180818 },
+};
+```

--- a/tools/local/create_dot_env.py
+++ b/tools/local/create_dot_env.py
@@ -1,0 +1,61 @@
+#!/usr/bin/env python
+
+from os.path import exists
+
+def read_config():
+    config_items = [
+        "monerod_ip",
+        "monerod_rpc_port",
+        "wallet_rpc_ip",
+        "wallet_rpc_port",
+        "wallet_file",
+        "wallet_password",
+        "nettype",
+        "test_pool_port",
+        "test_pool_webui_port",
+        "test_pool_wallet_address",
+        "test_pool_fee_wallet_address",
+        "test_build_dir"
+    ]
+
+    config_answers = {}
+
+    for key in config_items:
+        if key == "test_build_dir":
+            print("this path should be outside of the git repo pathspace")
+        config_answers[key] = input("{}: ".format(key))
+
+    return config_answers
+
+def write_dot_env(config_answers):
+    fh = open(".env", 'w')
+    for key in config_answers.keys():
+        fh.write('{}="{}"\n'.format(key, config_answers[key]))
+    fh.close()
+
+if __name__ == "__main__":
+    print("!!! PLEASE READ !!!")
+    print("This expects you to have a running mainnet/stagenet/testnet monerod")
+    print("and the monero-wallet-rpc and xmrig commands available in PATH")
+    print("You will also need to create wallets for the enviroments to use")
+    print("!!!!!!!!!!!!!!!!!!!")
+    if exists(".env"):
+        print("--- You have an existing environment ---")
+        with open(".env", 'r') as fh:
+            existing_env = fh.read()
+        print(existing_env)
+        print ("---")
+        retry = 0 
+        max_retry = 30
+        while True:
+            yn = input("keep? [(y)/n] ")
+            if yn.lower() in ['', 'y']:
+                exit(0)
+            if yn.lower() in ['n']:
+                break
+            retry = retry + 1
+            if retry > max_retry:
+                print("I remind you, this is a yes or no question")
+                exit(1)
+    write_dot_env(read_config())
+

--- a/tools/local/create_test_env.sh
+++ b/tools/local/create_test_env.sh
@@ -1,0 +1,36 @@
+#!/bin/bash
+
+activate_script="./testenv/bin/activate"
+if [ -f $activate_script ]; then
+    echo "testenv venv already exists rm -rf ./testenv/ to rebuild"
+else
+    echo "building new python venv `pwd`/testenv"
+    python -m venv ./testenv
+fi
+
+if [ -f $activate_script ]; then
+    source $activate_script
+else
+    echo "python venv testenv cannot find activate script"
+    exit 1
+fi
+
+echo installing requirements into venv
+pip install -r requirements.txt
+
+python create_dot_env.py
+
+if [[ $? -ne 0 ]] ; then
+    echo "Something went wrong!!"
+    exit 1
+fi
+
+./run_integ_tests.sh test_env.py
+
+if [[ $? -ne 0 ]] ; then
+    echo "Something went wrong!!"
+    exit 1
+else
+    echo "Environtment setup complete you can now run launch.sh"
+    echo "or launch_and_test.sh"
+fi

--- a/tools/local/kill_all_test_env_processes.sh
+++ b/tools/local/kill_all_test_env_processes.sh
@@ -1,0 +1,21 @@
+#!/bin/bash
+
+
+if [ ! -f ./.env ]; then
+    echo "please run ./create_test_env.sh"
+    exit 1
+fi
+
+source ./.env
+
+activate_script="./testenv/bin/activate"
+if [ ! -f $activate_script ]; then
+    echo "please run ./create_test_env.sh"
+    exit 1
+fi
+
+for i in `ls $test_build_dir/*.pid`; do
+    pid=`cat $i`
+    echo "killing $i at $pid"
+    kill $pid
+done

--- a/tools/local/launch.sh
+++ b/tools/local/launch.sh
@@ -1,0 +1,184 @@
+#!/bin/bash
+
+if [ ! -f ./.env ]; then
+    echo "please run ./create_test_env.sh"
+    exit 1
+fi
+
+source ./.env
+
+activate_script="./testenv/bin/activate"
+if [ ! -f $activate_script ]; then
+    echo "please run ./create_test_env.sh"
+    exit 1
+fi
+
+existing_pids=`ls $test_build_dir/*.pid`
+for i in $existing_pids; do
+    check_pid=`cat $i`
+    process_count=`ps aux | grep $check_pid | grep -v grep | wc -l`
+    if [ $process_count -gt 0 ]; then
+        echo "Found running processes, please run kill_all_test_env_processes.sh"
+        exit 1
+    fi
+done
+
+test_branch=$1
+build_type=$2
+
+if [ -z "$1" ]; then
+    test_branch="master"
+fi
+
+if [ -z "$2" ]; then
+    build_type="debug"
+fi
+git_root=`git rev-parse --show-toplevel`
+if [ -d $test_build_dir ]; then
+    echo testbuild directory exists, cleaning, and creating
+    rm -rf $test_build_dir
+    mkdir $test_build_dir
+else
+    echo creating testbuild directory
+    mkdir $test_build_dir
+fi
+
+mkdir $test_build_dir/data-dir
+
+if [ ! -d $test_build_dir ]; then
+    echo "$test_build_dir directory doesn't exist when it should"
+    exit 1
+fi
+
+git clone $git_root $test_build_dir/monero-pool
+cd $test_build_dir/monero-pool
+git checkout $test_branch
+if [ $build_type = 'release' ]; then
+    make release
+else
+    make
+fi
+
+if [ $? -ne 0 ]; then
+    echo "Build Failed!!"
+    exit 1
+fi
+
+echo "Creating test pool.conf file"
+echo > $test_build_dir/pool.conf
+echo pool-list = 0.0.0.0 >> $test_build_dir/pool.conf
+echo pool-port = $test_pool_port >> $test_build_dir/pool.conf
+echo pool-ssl-port = $test_pool_port >> $test_build_dir/pool.conf
+echo pool-syn-backlog = 16 >> $test_build_dir/pool.conf
+echo webui-list = 0.0.0.0 >> $test_build_dir/pool.conf
+echo webui-port = $test_pool_webui_port >> $test_build_dir/pool.conf
+echo rpc-host = $monerod_ip >> $test_build_dir/pool.conf
+echo rpc-port = $monerod_rpc_port >> $test_build_dir/pool.conf
+echo wallet-rpc-host = $wallet_rpc_ip >> $test_build_dir/pool.conf
+echo wallet-rpc-port = $wallet_rpc_port >> $test_build_dir/pool.conf
+echo rpc-timeout = 15 >> $test_build_dir/pool.conf
+echo idle-timeout = 150 >> $test_build_dir/pool.conf
+echo pool-wallet = $test_pool_wallet_address >> $test_build_dir/pool.conf
+echo pool-fee-wallet = $test_pool_fee_wallet_address >> $test_build_dir/pool.conf
+echo pool-start-diff = 1000 >> $test_build_dir/pool.conf
+echo pool-fixed-diff = 0 >> $test_build_dir/pool.conf
+echo pool-nicehash-diff = 280000 >> $test_build_dir/pool.conf
+echo pool-fee = 0.01 >> $test_build_dir/pool.conf
+echo payment-threshold = 0.33 >> $test_build_dir/pool.conf
+echo share-mul = 2.0 >> $test_build_dir/pool.conf
+echo retarget-time = 30 >> $test_build_dir/pool.conf
+echo retarget-ratio = 0.55 >> $test_build_dir/pool.conf
+echo log-level = 5 >> $test_build_dir/pool.conf
+echo log-file = $test_build_dir/test_pool.log >> $test_build_dir/pool.conf
+echo data-dir = $test_build_dir/data-dir >> $test_build_dir/pool.conf
+echo pid-file = $test_build_dir/test_pool.pid >> $test_build_dir/pool.conf
+echo forked = 1 >> $test_build_dir/pool.conf
+echo processes = 1 >> $test_build_dir/pool.conf
+echo cull-shares = 10 >> $test_build_dir/pool.conf
+
+echo "creating monero-wallet-rpc config file"
+
+echo > $test_build_dir/monero_wallet_rpc.conf 
+if [ -z "$nettype" ]; then
+    echo "nettype not set"
+    exit 1
+fi
+if [ $nettype == "stagenet" ]; then
+    echo stagenet=1 >> $test_build_dir/monero_wallet_rpc.conf
+elif [ $nettype == "testnet" ]; then
+    echo testnet=1 >> $test_build_dir/monero_wallet_rpc.conf
+fi
+echo log-file=$test_build_dir/test_monero_wallet_rpc.log >> $test_build_dir/monero_wallet_rpc.conf
+echo disable-rpc-login=1 >> $test_build_dir/monero_wallet_rpc.conf
+echo daemon-address=$monerod_ip:$monerod_rpc_port >> $test_build_dir/monero_wallet_rpc.conf
+echo trusted-daemon=1 >> $test_build_dir/monero_wallet_rpc.conf
+echo pidfile=$test_build_dir/test_monero_wallet_rpc.pid >> $test_build_dir/monero_wallet_rpc.conf
+echo wallet-file=$wallet_file >> $test_build_dir/monero_wallet_rpc.conf
+echo password=$wallet_password >> $test_build_dir/monero_wallet_rpc.conf
+echo rpc-bind-port=$wallet_rpc_port >> $test_build_dir/monero_wallet_rpc.conf
+echo rpc-bind-ip=$wallet_rpc_ip >> $test_build_dir/monero_wallet_rpc.conf 
+echo detach=1 >> $test_build_dir/monero_wallet_rpc.conf
+
+echo "Launching monero-wallet-rpc"
+
+monero-wallet-rpc --config-file $test_build_dir/monero_wallet_rpc.conf
+
+rpc_pid=`cat $test_build_dir/test_monero_wallet_rpc.pid`
+rpc_process=`ps aux | grep $rpc_pid | grep -v grep | wc -l`
+
+if [ $rpc_process -ne 1 ]; then
+    echo "failed to start monero-wallet-rpc"
+    echo "Please review $test_build_dir/test_monero_wallet_rpc.log"
+    exit 1
+fi
+
+sleep 5
+
+max_retry=30
+retry=0
+while true; do
+    curl -s http://$wallet_rpc_ip:$wallet_rpc_port/json_rpc -d '{"jsonrpc":"2.0","id":"0","method":"get_version"}' -H 'Content-Type: application/json' > /dev/null
+    if [ $? -eq 0 ]; then
+        break
+    fi
+    sleep 5
+    retry=$[$retry + 1]
+    if [ $retry -gt $max_retry ]; then
+        echo "monero-wallet-rpc api did not start responding";
+        echo "Please review $test_build_dir/test_monero_wallet_rpc.log"
+        exit 1
+    fi
+done
+
+cd build/$build_type
+./monero-pool -c $test_build_dir/pool.conf
+
+mp_pid=`cat $test_build_dir/test_pool.pid`
+mp_process=`ps aux | grep $mp_pid | grep -v grep | wc -l`
+echo $mp_process
+if [ $mp_process -ne 1 ]; then
+    echo "failed to start monero-pool"
+    echo "please review $test_build_dir/test_pool.log"
+    kill $rpc_pid
+    exit 1
+fi   
+
+retry=0
+while true; do
+	curl -s http://127.0.0.1:$test_pool_webui_port/stats > /dev/null
+	if [ $? -eq 0 ]; then
+		break
+	fi
+	sleep 5
+	retry=$[retry + 1]
+	if [ $retry -gt $max_retry ]; then
+		echo "monero-pool webui services not responding"
+		echo "please review $test_build_dir/test_pool.log"
+		kill $rpc_pid
+		kill $mp_pid
+		exit 1
+	fi
+done
+
+echo "Pool launch success"
+echo "Pool pid $mp_pid wallet_pid $rpc_pid"

--- a/tools/local/launch_and_test.sh
+++ b/tools/local/launch_and_test.sh
@@ -1,0 +1,35 @@
+#!/bin/bash
+
+if [ ! -f ./.env ]; then
+    echo "please run ./create_test_env.sh"
+    exit 1
+fi
+
+source ./.env
+
+activate_script="./testenv/bin/activate"
+if [ ! -f $activate_script ]; then
+    echo "please run ./create_test_env.sh"
+    exit 1
+fi
+test_branch=$1
+build_type=$2
+
+if [ -z "$1" ]; then
+    test_branch="master"
+fi
+
+if [ -z "$2" ]; then
+    build_type="debug"
+fi
+
+./launch.sh $test_branch $build_type
+
+if [ $? -ne 0 ]; then
+    echo "Launch script failed see above!!"
+    exit 1
+fi
+
+./run_integ_tests.sh
+
+./kill_all_test_env_processes.sh

--- a/tools/local/requirements.txt
+++ b/tools/local/requirements.txt
@@ -1,0 +1,4 @@
+requests
+pytest
+wheel
+monero

--- a/tools/local/run_integ_tests.sh
+++ b/tools/local/run_integ_tests.sh
@@ -1,0 +1,60 @@
+#!/bin/bash
+
+function print_mining_warning {
+    echo '!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!'
+    echo '!!! WARNING WARNING WARNING WARNING !!!'
+    echo '!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!'
+    echo
+    echo "WARN This will launch xmrig and attempt to mine a block"
+    echo "WARN This will considerably tax your build system"
+    echo "WARN If you are on a cloud REVIEW your EULA running any"
+    echo "WARN miner maybe seen as a violation of the EULA"
+    echo "WARN and be grounds to terminate your account"
+    echo
+    echo "If you want to speed up the blockfind, connect your own HR to pool"
+    echo "with a fixed difficulty of 300000 a hashrate of ~1000"
+    echo "should find a block within the testing window"
+}
+
+if [ ! -f ./.env ]; then
+    echo "please run ./create_test_env.sh"
+    exit 1
+fi
+
+source ./.env
+
+activate_script="./testenv/bin/activate"
+if [ ! -f $activate_script ]; then
+    echo "please run ./create_test_env.sh"
+    exit 1
+fi
+
+source $activate_script
+
+git_root=`git rev-parse --show-toplevel`
+
+cd $git_root/test/integ
+
+if [ $nettype = 'stagenet' ]; then
+    print_mining_warning
+fi
+
+if [ $nettype = 'testnet' ]; then
+    print_mining_warning
+fi
+
+if [ -z "$1" ]; then
+    pytest 
+else
+    pytest $1
+fi
+
+# kill any stray xmrig processes that have not respected our kills
+xmrigs=`ps aux | grep xmrig | grep -v grep | grep $test_build_dir`
+if [ -z "$xmrigs" ]; then
+    echo "killing xmrigs"
+    echo $xmrigs
+fi
+for pid in `ps aux | grep xmrig | grep -v grep | grep $test_build_dir | awk '{print $2}'`; do
+    kill $pid
+done


### PR DESCRIPTION
Please let me know if you want this testkit.  I wrote it to test while I'm making updates.

`create_test_env.sh` - creates the runtime environment
<img width="767" alt="create_test_env" src="https://user-images.githubusercontent.com/20960742/126140648-091783b7-3834-4a85-b4d9-40523c74df7f.png">

`launch.sh` - builds and starts the pool services for testing, $1=branchname $2=buildtype  if not specified they will default to master/debug
<img width="767" alt="launch" src="https://user-images.githubusercontent.com/20960742/126141250-643b9863-678b-4b90-807e-49724af22dd7.png">

`run_integ_tests.sh` - run all integration tests or specify a single test file to run at $1
<img width="769" alt="run_integ_tests sh" src="https://user-images.githubusercontent.com/20960742/126141271-a23340da-8a05-41e4-bc67-5be896343222.png">

`launch_and_test.sh` - launches, and runs integration tests, and then kills the environment takes the same parameters as launch.sh

`kill_all_test_env_processes.sh` - used to kill any stray processes 

A private stagenet with fixed diff of 300000 can pass all tests in two minutes with a hashrate of 2500h/s

If you want to setup your own stagenet see:
example stagenet https://github.com/moneroexamples/private-testnet/blob/master/make_private_stagenet.sh

If you start an empty blockchain stagenet or testnet you may want to edit the src/hardforks/hardforks.cpp before you compile your private [stage|test]net to quickly get to the latest version.   Mine in monerod after the [stage|test]net is setup, and then start mining with the pool software after hitting the latest version of the block.   See the below changes to stagenet_hard_forks. Only do this on a private [state|test]net.

```
const hardfork_t stagenet_hard_forks[] = {
  // version 1 from the start of the blockchain
  { 1, 1, 0, 1341378000 },

  // versions 2-7 in rapid succession from March 13th, 2018
  { 2, 2, 0, 1521000000 },
  { 3, 3, 0, 1521120000 },
  { 4, 4, 0, 1521240000 },
  { 5, 5, 0, 1521360000 },
  { 6, 6, 0, 1521480000 },
  { 7, 7, 0, 1521600000 },
  { 8, 8, 0, 1537821770 },
  { 9, 9, 0, 1537821771 },
  { 10, 10, 0, 1550153694 },
  { 11, 11, 0, 1550225678 },
  { 12, 12, 0, 1571419280 },
  { 13, 675405, 0, 1598180817 },
  { 14, 676125, 0, 1598180818 },
};
```