### PR TITLE
log: add addr, round hr, net dif, height to MINED

### DIFF
--- a/src/pool.c
+++ b/src/pool.c
@@ -3273,7 +3273,7 @@ miner_on_submit(json_object *message, client_t *client)
     }
 
     log_trace("Miner submitted nonce=%u, result=%s, host=%s:%u, "
-            "address=%s, rig_id=%s",
+            "address=%.12s, rig_id=%s",
             result_nonce, result_hex, client->host, client->port,
             client->address, client->rig_id);
     /*
@@ -3463,7 +3463,13 @@ post_hash:
     if (BN_cmp(hd, bd) >= 0)
     {
         /* Yay! Mined a block so submit to network */
-        log_info("+++ MINED A BLOCK +++");
+        log_info("+++ MINED A BLOCK +++ "
+                 "address=%.12s, round=%"PRIu64", diff=%"PRIu64", "
+                 "height=%"PRIu64,
+                 client->address,
+                 pool_stats.round_hashes + job->target,
+                 pool_stats.network_difficulty,
+                 pool_stats.network_height);
         char *block_hex = calloc((bin_size << 1)+1, sizeof(char));
         bin_to_hex(block, bin_size, block_hex, bin_size << 1);
         char body[RPC_BODY_MAX] = {0};


### PR DESCRIPTION
Logging changes, use case to scrape logs for effort data when block is found.

```
2021-07-26 23:55:36 TRACE src/pool.c:3275: Miner submitted nonce=98345, result=c6136bb90ec8468bcbfa85ff90d5939e9f19eec3cc571e7240e478aea7e22c00, host=127.0.0.1:46828, address=5BXAsDboVYEQ, rig_id=monero_pool_int_test
2021-07-26 23:56:08 TRACE src/pool.c:3275: Miner submitted nonce=98520, result=7cdf6c66475d403140f1d49ac35f080f3c3c77a41ce1815187db5c7f80a52e00, host=127.0.0.1:46828, address=5BXAsDboVYEQ, rig_id=monero_pool_int_test
2021-07-26 23:56:08 TRACE src/pool.c:3275: Miner submitted nonce=34017, result=720d1089a6e7e387c4c1d5ff153c13b0194667189de1ce5498fce688ac620100, host=127.0.0.1:46828, address=5BXAsDboVYEQ, rig_id=monero_pool_int_test
2021-07-26 23:56:08 TRACE src/pool.c:3275: Miner submitted nonce=34160, result=260d640d1147853376924766ff4914aa35d77de00928a3da250853b4e63d2200, host=127.0.0.1:46828, address=5BXAsDboVYEQ, rig_id=monero_pool_int_test

```

```
2021-07-26 23:56:20 INFO  src/pool.c:3466: +++ MINED A BLOCK +++ address=55hKAMnUWXaW, round=609000, diff=600000, height=2756
2021-07-26 23:57:13 INFO  src/pool.c:3466: +++ MINED A BLOCK +++ address=55hKAMnUWXaW, round=631107, diff=600000, height=2757
2021-07-26 23:59:29 INFO  src/pool.c:3466: +++ MINED A BLOCK +++ address=55hKAMnUWXaW, round=660352, diff=600000, height=2758
2021-07-26 23:59:36 INFO  src/pool.c:3466: +++ MINED A BLOCK +++ address=55hKAMnUWXaW, round=300000, diff=600000, height=2759
2021-07-27 00:00:33 INFO  src/pool.c:3466: +++ MINED A BLOCK +++ address=5BXAsDboVYEQ, round=327764, diff=600000, height=2760
```