### PR TITLE
fixed typecast and --self-select bug.

### DIFF
--- a/src/xmr.cpp
+++ b/src/xmr.cpp
@@ -206,7 +206,7 @@ int validate_block_from_blob(const char *blob_hex,
     if (!find_tx_extra_field_by_type(tx_extra_fields, pub_key_field, 0))
         return XMR_TX_EXTRA_ERROR;
     public_key R = pub_key_field.pub_key;
-    public_key P = boost::get<txout_to_key>(tx.vout[0].target).key;
+    public_key P = boost::get<txout_to_tagged_key>(tx.vout[0].target).key;
     key_derivation derivation;
     generate_key_derivation(R, v, derivation);
     public_key derived;


### PR DESCRIPTION
1) the file xmr.cpp had a wrong typecast not updated after the fork.
txout_to_key passes to txout_to_tagged_key. (thx to jeffro256)

2) In the file pool.c it is assumed that "bstack(bst)" always has the actual "top" when invoking the method "miner_on_block_template". If so, the pool defines for the miners which network height and difficulty is current. This is also present in the static variables pool_stats.network_difficulty and pool_stats.network_height.